### PR TITLE
Adds padding to body on raw template.

### DIFF
--- a/raw/index.jade
+++ b/raw/index.jade
@@ -39,7 +39,7 @@ html(lang="en")
 			//if lt IE 9
 				script(src="static/demo/html5shiv-printshiv.js")
 
-	body
+	body(style="padding:4px;")
 		each component in document.components
 			if(component.family == templateData.family)
 				if(!component.eof && component.patterns)


### PR DESCRIPTION
Once normalize is added via cf-grunt-config the demo will not have any padding on the body. This adds back some slim padding. I know it's not much but If we add any more then the cf-buttons demo will push one of the three buttons to the next line on the ios simulator.

Also I figure an inline style was better than having to add a stylesheet just for this one little thing.
