### PR TITLE
Add IE8-only JS fix for icon font

### DIFF
--- a/raw/index.jade
+++ b/raw/index.jade
@@ -46,7 +46,7 @@ html(lang="en")
 					cfHead.appendChild(cfStyle);
 					setTimeout(function(){
 							cfHead.removeChild(cfStyle);
-					}, 100);
+					}, 300);
 
 	body(style="padding:4px;")
 		each component in document.components


### PR DESCRIPTION
See discussion at cfpb/cf-icons#2. This fix is in the same section as the html5shiv script. It'll only load in IE8 and when the `html5shiv` option is set.
