### PR TITLE
Allows the IE8 font face hack to be triggered on its own instead of being coupled with the html5shim.

### DIFF
--- a/raw/index.jade
+++ b/raw/index.jade
@@ -34,19 +34,22 @@ html(lang="en")
 			//if lt IE 8
 				link(rel = 'stylesheet', type = 'text/css', href = templateData.ltIE8Source)
 
-		if(templateData.html5Shiv)
+		if(templateData.html5Shiv || templateData.ie8FontFaceHack)
 			= '\n'
 			//if lt IE 9
-				script(src="static/demo/html5shiv-printshiv.js")
-				script.
-					var cfHead = document.getElementsByTagName('head')[0],
-							cfStyle = document.createElement('style');
-					cfStyle.type = 'text/css';
-					cfStyle.styleSheet.cssText = ':before,:after{content:none !important}';
-					cfHead.appendChild(cfStyle);
-					setTimeout(function(){
-							cfHead.removeChild(cfStyle);
-					}, 300);
+				if(templateData.html5Shiv)
+					script(src="static/demo/html5shiv-printshiv.js")
+
+				if(templateData.ie8FontFaceHack)
+					script.
+						var cfHead = document.getElementsByTagName('head')[0],
+								cfStyle = document.createElement('style');
+						cfStyle.type = 'text/css';
+						cfStyle.styleSheet.cssText = ':before,:after{content:none !important}';
+						cfHead.appendChild(cfStyle);
+						setTimeout(function(){
+								cfHead.removeChild(cfStyle);
+						}, 300);
 
 	body(style="padding:4px;")
 		each component in document.components


### PR DESCRIPTION
I wanted to decouple the IE8 Font Face hack from the HTML5 Shim. You dig?
