### PR TITLE
Improved gitignore and removed references to Avenir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+# Grunt & Bower #
+#################
 node_modules/
 bower_components/
 vendor/
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 0.9.2 - 2015-05-13
+
+### Changed
+- Removed Avenir from the code examples
+
 ## 0.9.1 - 2015-01-06
 
 ### Added

--- a/docs-src/testing-remove-when-done.html
+++ b/docs-src/testing-remove-when-done.html
@@ -134,12 +134,12 @@
                     <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Mollitia alias accusantium facilis aspernatur numquam tenetur perferendis delectus impedit voluptates earum sed minima consequuntur quis velit consequatur id sunt distinctio non.</li>
                   </ul>
                 </footer>
-              </div>          
+              </div>
             </div>
             <div class="docs-css">
               <pre class="css"><code data-language="css">.media-object_header {
     margin-top: 0;
-    font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
     margin-bottom: 0.22727272727272727em;
@@ -149,7 +149,7 @@
     @media only all and (min-width: 48em) {
     .media-object_header {
       margin-top: 0;
-      font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+      font-family: Arial, sans-serif;
       font-style: normal;
       font-weight: normal;
       margin-bottom: 0.3076923076923077em;
@@ -158,13 +158,13 @@
     }
     }
     .media-object_text {
-    font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
     color: #43484e;
     }
     .media-object_byline {
-    font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
     }</code></pre>
@@ -212,7 +212,7 @@
             <div class="docs-css">
               <pre class="css"><code data-language="css">.media-object_header {
     margin-top: 0;
-    font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
     margin-bottom: 0.22727272727272727em;
@@ -222,7 +222,7 @@
     @media only all and (min-width: 48em) {
     .media-object_header {
       margin-top: 0;
-      font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+      font-family: Arial, sans-serif;
       font-style: normal;
       font-weight: normal;
       margin-bottom: 0.3076923076923077em;
@@ -231,13 +231,13 @@
     }
     }
     .media-object_text {
-    font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
     color: #43484e;
     }
     .media-object_byline {
-    font-family: &quot;AvenirNextLTW01-Regular&quot;, Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
     }</code></pre>


### PR DESCRIPTION
This is mostly cosmetic, but part of the removing references to Avenir.

## Additions
-  More robust .gitignore rules

## Removals

- Removed references to Avenir

## Review

- @Scotchester 

## Preview

[Preview this PR without the whitespace changes](?w=0)

## Notes

- Part of https://github.com/cfpb/capital-framework/issues/161